### PR TITLE
Support for Submodules

### DIFF
--- a/gitclone.lua
+++ b/gitclone.lua
@@ -26,11 +26,11 @@ local function clone(files)
 
     local downloadedCount = 0
 
-    local function step_progress()
+    local function step_progress(leading_text)
         term.setCursorPos(x, y)
         term.clearLine()
         downloadedCount = downloadedCount + 1
-        local progressText = 'Receiving files:  ' .. (downloadedCount / #files * 100) .. '% (' .. downloadedCount .. '/' .. #files .. ')'
+        local progressText = leading_text .. ': ' .. (downloadedCount / #files * 100) .. '% (' .. downloadedCount .. '/' .. #files .. ')'
         if downloadedCount ~= #files then
             term.write(progressText)
         else
@@ -44,7 +44,7 @@ local function clone(files)
 
             if fs.exists(filePath) then
                 if fs.getSize(filePath) == files[i].size then
-                    step_progress()
+                    step_progress('Checking files')
                     return
                 end
             end
@@ -61,7 +61,7 @@ local function clone(files)
             local writer = fs.open(filePath, mode)
             writer.write(content or '')
             writer.close()
-            step_progress()
+            step_progress('Receiving files')
         end
         table.insert(processes, download)
     end

--- a/gitclone.lua
+++ b/gitclone.lua
@@ -14,6 +14,8 @@ local repo = args[2]
 local branch = args[3]
 local localPath = args[4] or shell.dir()
 
+local localRepoPath = fs.combine(localPath, repo)
+
 treeUrl = treeUrl:gsub('%[USER]', user)
 treeUrl = treeUrl:gsub('%[REPO]', repo)
 treeUrl = treeUrl:gsub('%[BRANCH]', branch)
@@ -21,11 +23,6 @@ treeUrl = treeUrl:gsub('%[BRANCH]', branch)
 local function clone(files)
     local processes = {}
     local x, y = term.getCursorPos()
-
-    local localRepoPath = fs.combine(localPath, repo)
-    if fs.exists(localRepoPath) then
-        fs.delete(localRepoPath)
-    end
 
     local downloadedCount = 0
     for i=1, #files do
@@ -40,9 +37,9 @@ local function clone(files)
             if files[i].binary then
                 mode = 'wb'
             end
-            
+
             local writer = fs.open(filePath, mode)
-            writer.write(content)
+            writer.write(content or '')
             writer.close()
 
             term.setCursorPos(x, y)
@@ -60,13 +57,62 @@ local function clone(files)
     parallel.waitForAll(table.unpack(processes))
 end
 
+local function parseGitModules()
+    local gitModulesPath = fs.combine(localPath, repo, '.gitmodules')
+    if not fs.exists(gitModulesPath) then
+        return {}
+    end
+
+    local file = fs.open(gitModulesPath, 'r')
+    local content = file.readAll()
+    file.close()
+
+    local modules = {}
+    for module, path, url in content:gmatch('%[submodule "(.-)"%][^%[]-path = (.-)\n[^%[]-url = (.-)\n') do
+        table.insert(modules, {path = path, url = url})
+    end
+
+    return modules
+end
+
+local function cloneSubmodules(modules)
+    for _, module in ipairs(modules) do
+        local submodulePath = fs.combine(localPath, repo, module.path)
+        local user, submoduleRepo = module.url:match('https://github.com/(.-)/([^.]+)')
+        local submoduleBranch = 'master'  -- Assuming 'master' as default branch
+        local submoduleTreeUrl = 'https://api.github.com/repos/' .. user .. '/' .. submoduleRepo .. '/git/trees/' .. submoduleBranch .. '?recursive=1'
+        local submoduleRawFileUrl = 'https://raw.githubusercontent.com/' .. user .. '/' .. submoduleRepo .. '/' .. submoduleBranch .. '/[PATH]'
+
+        local res, reason = http.get(submoduleTreeUrl)
+        if not reason then
+            local tree = res.readAll()
+            tree = textutils.unserialiseJSON(tree)
+            local files = {}
+            for k, entry in pairs(tree.tree) do
+                if entry.type ~= "tree" and entry.type ~= "commit" then
+                    local url = submoduleRawFileUrl:gsub('%[PATH]', entry.path)
+                    table.insert(files, { path = module.path .. '/' .. entry.path, url = url, binary = entry.type == "blob" })
+                end
+            end
+            print('Cloning submodule into ' .. submodulePath .. '...')
+            clone(files)
+        else
+            printError(reason)
+        end
+    end
+end
+
 local res, reason = http.get(treeUrl)
 if not reason then
+    if fs.exists(localRepoPath) then
+        fs.delete(localRepoPath)
+    end
+
     local tree = res.readAll()
     tree = textutils.unserialiseJSON(tree)
     local files = {}
-    for k,entry in pairs(tree.tree) do
-        if entry.type ~= "tree" then
+    for k, entry in pairs(tree.tree) do
+        if entry.type ~= "tree" and entry.type ~= "commit" then
             local url = rawFileUrl
             url = url:gsub('%[USER]', user)
             url = url:gsub('%[REPO]', repo)
@@ -77,6 +123,10 @@ if not reason then
     end
     print('Cloning into ' .. repo .. '...')
     clone(files)
+
+    -- Handle submodules
+    local modules = parseGitModules()
+    cloneSubmodules(modules)
 else
     printError(reason)
 end


### PR DESCRIPTION
## Description
This pull request adds support for downloading submodules of the target repository. Also implements checking files, instead of redundantly downloading files which already exist.

## Features
- Take all of the submodules described in the repo's `.gitmodules` and subsequently download all of submodule's files to its respective path.
- For all the files in the main repository, check if the file to be downloaded already exists and has the same size as described by GitHub's API. If it's already present and has the same size, it's skipped.
- For submodules, if the folder for the submodule already exists, it's skipped.

## Screenshots

### Downloading repos with submodules
This is an example of the program's behaviour when downloading from [CC-Busted](https://github.com/Commandcracker/CC-Busted), a repository which contains submodules.

https://github.com/Konijima/cc-git-clone/assets/43142209/1d5a4ad8-e2b1-4843-973c-1987d5f4168f


### Skipping downloads if it's already downloaded
This is an example of the program's behaviour when the repository is already fully downloaded. It will check and subsequently skip all of the files and submodules.

https://github.com/Konijima/cc-git-clone/assets/43142209/bc14390e-dcf0-4e9f-83ea-c89c0238bf2c

